### PR TITLE
Fixed wrong conversion of celsius to fahrenheit.

### DIFF
--- a/_build/html/nivel1/seccion1-2.html
+++ b/_build/html/nivel1/seccion1-2.html
@@ -364,7 +364,7 @@
 <ol class="simple">
 <li><p>Abra el REPL en su computador, copie las instrucciones del ejemplo y revise que el resultado sea similar.</p></li>
 <li><p>Evalúe en el REPL la instrucción <code class="docutils literal notranslate"><span class="pre">10/3</span></code>. ¿Qué piensa del resultado? ¿Es el que usted esperaba?</p></li>
-<li><p>Escriba la instrucción que convierta 15 grados Celsius al equivalente en grados Fahrenheit. Recuerde que cada grado Fahrenheit equivale a 5 novenos de un grado Celsius y que la escala está desplazada 32 grados. Ayuda: 0 grados Celsius equivalen a -32 grados Fahrenheit, 37.5 (la temperatura aproximada de un cuerpo humano) equivalen a 99.5, y 15 grados Celsius equivalen a 59 grados Fahrenheit.</p></li>
+<li><p>Escriba la instrucción que convierta 15 grados Celsius al equivalente en grados Fahrenheit. Recuerde que cada grado Fahrenheit equivale a 5 novenos de un grado Celsius y que la escala está desplazada 32 grados. Ayuda: 0 grados Celsius equivalen a 32 grados Fahrenheit, 37.5 (la temperatura aproximada de un cuerpo humano) equivalen a 99.5, y 15 grados Celsius equivalen a 59 grados Fahrenheit.</p></li>
 </ol>
 </div>
 <div class="section" id="linea-de-comandos-terminal-consola">

--- a/nivel1/seccion1-2.md
+++ b/nivel1/seccion1-2.md
@@ -98,7 +98,7 @@ Captura de pantalla de IPython
 
 1. Abra el REPL en su computador, copie las instrucciones del ejemplo y revise que el resultado sea similar.
 2. Evalúe en el REPL la instrucción ```10/3```. ¿Qué piensa del resultado? ¿Es el que usted esperaba?
-3. Escriba la instrucción que convierta 15 grados Celsius al equivalente en grados Fahrenheit. Recuerde que cada grado Fahrenheit equivale a 5 novenos de un grado Celsius y que la escala está desplazada 32 grados. Ayuda: 0 grados Celsius equivalen a -32 grados Fahrenheit, 37.5 (la temperatura aproximada de un cuerpo humano) equivalen a 99.5, y 15 grados Celsius equivalen a 59 grados Fahrenheit.
+3. Escriba la instrucción que convierta 15 grados Celsius al equivalente en grados Fahrenheit. Recuerde que cada grado Fahrenheit equivale a 5 novenos de un grado Celsius y que la escala está desplazada 32 grados. Ayuda: 0 grados Celsius equivalen a 32 grados Fahrenheit, 37.5 (la temperatura aproximada de un cuerpo humano) equivalen a 99.5, y 15 grados Celsius equivalen a 59 grados Fahrenheit.
 
 
 


### PR DESCRIPTION
0 degrees celsius is 32 degrees fahrenheit, not -32.